### PR TITLE
Update ultimate-upscale.py

### DIFF
--- a/scripts/ultimate-upscale.py
+++ b/scripts/ultimate-upscale.py
@@ -353,7 +353,7 @@ class USDUSeamsFix():
         for xi in range(1, cols):
             if state.interrupted:
                     break
-            p.width = self._width + self.padding * 2
+            p.width = self.width + self.padding * 2
             p.height = image.height
             p.inpaint_full_res = True
             p.inpaint_full_res_padding = self.padding


### PR DESCRIPTION
Changed _width into width on line 356

On my system, this fixes the bug documented here on the main project: https://github.com/Coyote-A/ultimate-upscale-for-automatic1111/issues/5

But there is another bug that appears after fixing this first one. 
The log for this new bug: `ValueError: Coordinate 'right' is less than 'left'`

